### PR TITLE
Fix plugins/zod doc

### DIFF
--- a/docs/reference/plugins/zod.md
+++ b/docs/reference/plugins/zod.md
@@ -21,7 +21,7 @@ You need to enable `@core/zod` plugin if you use the [Express.js](/docs/referenc
 
 ```prisma title='/schema.zmodel'
 plugin zod {
-  provider = '@zenstackhq/zod'
+  provider = '@core/zod'
   output = "./src/lib/zod"
 }
 ```


### PR DESCRIPTION
I am attempting my first OSS contribution and  I apologize in advance if I come across as rude or inexperienced.

While following the instructions in this document, I encountered an error:
```
Unable to load plugin module @zenstackhq/zod: @zenstackhq/zod, Error: Cannot find module '@zenstackhq/zod'
```
I guessed that changing `@zenstackhq/zod` to `@core/zod` was the correct solution, and after making the change, the error was resolved.