### PR TITLE
used `contains` instead of `search` in `search()` example

### DIFF
--- a/versioned_docs/version-1.x/the-complete-guide/part1/4-access-policy/4.5-expr-func.md
+++ b/versioned_docs/version-1.x/the-complete-guide/part1/4-access-policy/4.5-expr-func.md
@@ -118,7 +118,7 @@ The comparison is case-sensitive by default. You can also pass a third argument 
 Returns if a string field matches the search condition with [full-text-search](https://www.prisma.io/docs/concepts/components/prisma-client/full-text-search). Need to enable Prisma's "fullTextSearch" preview feature to use.
 
 ```zmodel
-@@allow('read', contains(title, 'zenstack is awesome'))
+@@allow('read', search(title, 'zenstack is awesome'))
 ```
 
 #### startsWith()


### PR DESCRIPTION
it look like a small mistake. just learning zenstack. awesome project and really awesome docs by the way.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the guide on modifying permission rules to use `search` for string field matching with full-text search in Prisma, enhancing the logic of search conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->