### PR TITLE
Nit: Should use "image" instead of "content"

### DIFF
--- a/blog/ocp/index.md
+++ b/blog/ocp/index.md
@@ -472,7 +472,7 @@ export const Post = ({ content }: { content: Content }) => {
 
 export const Image = ({ content }: { content: Content }) => {
   const image = content as Image;
-  return (<Image src= {content.url || ""} alt={content.id} />);
+  return (<Image src= {image.url || ""} alt={image.id} />);
 };
 ```
 


### PR DESCRIPTION
Nit: Should use "image" since the "content" has been cast to image type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated variable names in blog components for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->