### PR TITLE
Update 5-documentation.md to add prefix in openai plugin code snippet

### DIFF
--- a/docs/the-complete-guide/part3/5-documentation.md
+++ b/docs/the-complete-guide/part3/5-documentation.md
@@ -31,6 +31,7 @@ plugin openapi {
     title = "My Todo API"
     version = "1.0.0"
     flavor = "rpc"
+    prefix = '/api'
 }
 ```
 


### PR DESCRIPTION
the "./api" prefix is missing in the code snippet of setting up openai plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the API documentation guide to include information on configuring the `prefix` setting under the `openapi` plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->