### PR TITLE
Update 1-using-plugins.md

### DIFF
--- a/docs/the-complete-guide/part2/1-using-plugins.md
+++ b/docs/the-complete-guide/part2/1-using-plugins.md
@@ -29,4 +29,4 @@ plugin openapi {
 
 A plugin declaration requires a mandatory `provider` field that specifies the package name or Javascript module path of the plugin (which the `zenstack` CLI imports directly with `require()`). It can also contain other mandatory and optional fields specific to the plugin.
 
-When you run `zenstack generate`, the plugin will be executed and generate the output files.
+When you run `npx zenstack generate`, the plugin will be executed and generate the output files.


### PR DESCRIPTION
Running just `zenstack generate` it fails because in other examples it is used as `npx zenstack generate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the command for running plugins from `zenstack generate` to `npx zenstack generate` in the complete guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->