### PR TITLE
fix: readable max width docs style

### DIFF
--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -5,6 +5,8 @@
 
 @media (min-width: 997px) {
   .docItemCol {
-    max-width: 75% !important;
+      --readableMaxWidth: calc(calc(1080px*0.25)*3);
+      max-width: var(--readableMaxWidth) !important;
+      margin: 0 auto;
   }
 }


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/0ce8064f-5b9e-4617-ae99-8fd82dc82916)

After
![image](https://github.com/user-attachments/assets/a6e9c0aa-a88d-4abf-bdcf-b0751d01c2ee)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved responsive design for document items, enhancing adaptability to various screen sizes.
	- Introduced a centered layout for better visual presentation on wider screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->