### PR TITLE
docs: remove v2 notification

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,11 +63,6 @@ const config = {
     themeConfig:
         /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
         {
-            announcementBar: {
-                id: 'v2_announcement',
-                content: '🎉 <a href="/blog/v2-stories">ZenStack V2</a> is released 🥳️!',
-            },
-
             colorMode: {
                 defaultMode: 'light',
                 respectPrefersColorScheme: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the announcement bar from the user interface, which previously displayed updates about "ZenStack V2."

- **Chores**
	- Updated configuration settings while maintaining the overall theme structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->