### PR TITLE
docs: add missing `nanoid` function doc

### DIFF
--- a/docs/reference/zmodel-language.md
+++ b/docs/reference/zmodel-language.md
@@ -873,6 +873,14 @@ function cuid(): String {}
 
 Generates a globally unique identifier based on the [CUID](https://github.com/ericelliott/cuid) spec.
 
+##### nanoid()
+
+```zmodel
+function nanoid(length: Int?): String {}
+```
+
+Generates an identifier based on the [nanoid](https://github.com/ai/nanoid) spec.
+
 ##### now()
 
 ```zmodel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `nanoid()` function for generating unique identifiers in the ZModel language.
	- Enhanced documentation with descriptions and code snippets for the new function.

- **Documentation**
	- Updated reference materials to include the new `nanoid()` function and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->