### PR TITLE
doc: notes about using context providers with RSC

### DIFF
--- a/docs/reference/plugins/tanstack-query.mdx
+++ b/docs/reference/plugins/tanstack-query.mdx
@@ -183,6 +183,31 @@ provideHooksContext({
 
 </Tabs>
 
+:::info Notes about Next.js app router
+
+Next.js's app router renders components as React Server Components (RSC) by default. React context providers are not supported in RSC. If you're configuring the context providers in such a setup, please make sure to wrap them inside a client component, or set the containing layout as client component.
+
+```tsx title='providers.tsx'
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Provider as ZenStackHooksProvider } from "@/hooks/generated";
+import type { ReactNode } from 'react';
+
+const queryClient = new QueryClient();
+
+export default function Providers({ children }: { children: ReactNode }) {
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ZenStackHooksProvider value={{ endpoint: '/api/model' }}>
+                {children}
+            </ZenStackHooksProvider>
+        </QueryClientProvider>
+    );
+}
+```
+:::
+
 ### Example
 
 Here's a quick example with a ReactJs blogging app. You can find a fully functional Todo app example [here](https://github.com/zenstackhq/sample-todo-nextjs-tanstack).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidance on using the `@zenstackhq/tanstack-query` plugin with Next.js, including context provider usage.
	- Added information on automatic invalidation in mutation hooks.
	- Detailed the query key scheme for better understanding of cache organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->