### PR TITLE
doc: fix the create-t3 version for quick-start guide

### DIFF
--- a/docs/quick-start/nextjs-app-router.mdx
+++ b/docs/quick-start/nextjs-app-router.mdx
@@ -32,7 +32,7 @@ You can find the final build result [here](https://github.com/zenstackhq/docs-tu
 The easiest way to create a Next.js project with boilerplates is with `create-t3-app`. Run the following command to create a new project with Prisma, NextAuth and TailwindCSS.
 
 ```bash
-npx create-t3-app@latest --prisma --nextAuth --tailwind --appRouter --CI my-blog-app
+npx create-t3-app@7.39.3 --prisma --nextAuth --tailwind --appRouter --CI my-blog-app
 cd my-blog-app
 ```
 

--- a/docs/quick-start/nextjs.mdx
+++ b/docs/quick-start/nextjs.mdx
@@ -32,7 +32,7 @@ You can find the final build result [here](https://github.com/zenstackhq/docs-tu
 The easiest way to create a Next.js project with boilerplates is with `create-t3-app`. Run the following command to create a new project with Prisma, NextAuth and TailwindCSS.
 
 ```bash
-npx create-t3-app@latest --prisma --nextAuth --tailwind --CI my-blog-app
+npx create-t3-app@7.39.3 --prisma --nextAuth --tailwind --CI my-blog-app
 cd my-blog-app
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the quick start guide to specify a fixed version for the Next.js project creation command, ensuring consistent setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->