### PR TITLE
doc: fix nuxt auth starter link

### DIFF
--- a/docs/quick-start/nuxt.mdx
+++ b/docs/quick-start/nuxt.mdx
@@ -33,7 +33,7 @@ Although authentication is not the focus of the project, we need a basic signup/
 First, make a copy of the project using [degit](https://github.com/Rich-Harris/degit), install dependencies, and start the dev server:
 
 ```bash
-npx degit nuxt/examples/auth/local my-nuxt-blog
+npx degit nuxt/examples/examples/auth/local my-nuxt-blog
 cd my-nuxt-blog
 npm install
 npm run dev

--- a/versioned_docs/version-1.x/quick-start/nuxt.mdx
+++ b/versioned_docs/version-1.x/quick-start/nuxt.mdx
@@ -32,7 +32,7 @@ Although authentication is not the focus of the project, we need a basic signup/
 First, make a copy of the project using [degit](https://github.com/Rich-Harris/degit), install dependencies, and start the dev server:
 
 ```bash
-npx degit nuxt/examples/auth/local my-nuxt-blog
+npx degit nuxt/examples/examples/auth/local my-nuxt-blog
 cd my-nuxt-blog
 npm install
 npm run dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the command for cloning the Nuxt example project to ensure it references the proper repository path in the quick start guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->