### PR TITLE
Update nestjs.mdx

### DIFF
--- a/docs/quick-start/nestjs.mdx
+++ b/docs/quick-start/nestjs.mdx
@@ -69,8 +69,8 @@ model Post {
   updatedAt DateTime @updatedAt()
   title String
   published Boolean @default(false)
-  author User @relation(fields: [authorId], references: [id])
-  authorId Int @default(auth().id)
+  author User? @relation(fields: [authorId], references: [id])
+  authorId Int?
 }
 ```
 


### PR DESCRIPTION
`@default(auth().id)` does not seem to be supported by prisma

also made author and authorId optonal to align with the zModel code further down