### PR TITLE
add a community packages page

### DIFF
--- a/docs/community-packages.md
+++ b/docs/community-packages.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 7
+sidebar_label: Community Packages
+---
+
+# Community Packages
+
+Our wonderful community has created the following packages that extend ZenStack's functionality.
+
+- [ZenStack GraphQL Plugin](https://github.com/hakutakuAi/zenstack-graphql) by [hakutakuAi](https://github.com/hakutakuAi)
+  
+    This plugin generates a complete GraphQL schema with relations, filtering, sorting, and pagination. Saving you hours of boilerplate code to match your database models with you graphql server.
+
+- [ZenStack UI](https://github.com/kirankunigiri/zenstack-ui) by [Kiran Kunigiri](https://github.com/kirankunigiri)
+
+    Zenstack UI is a React UI library for automating form and list generation with Zenstack. It utilizes Zenstack metadata to automatically generate forms and perform required queries and mutations.

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Sample Projects
 ---
 
-# A Catalog of Sample Projects
+# Sample Projects
 
 The ZenStack team maintains the following three series of sample projects.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -3,7 +3,7 @@ description: How to upgrade to ZenStack v2
 
 slug: /upgrade-v2
 sidebar_label: Upgrading to V2
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Community Packages" page highlighting third-party extensions for ZenStack, including descriptions and links.
  * Updated sidebar positions for "Sample Projects" and "Upgrade" documentation pages.
  * Renamed the main heading of the "Sample Projects" page for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->