### PR TITLE
doc: add tanstack-query angular support attribution

### DIFF
--- a/docs/reference/plugins/tanstack-query.mdx
+++ b/docs/reference/plugins/tanstack-query.mdx
@@ -35,7 +35,7 @@ npm install --save-dev @zenstackhq/tanstack-query
 | -------- | ------- | ------------------------------------------------------- | -------- | ------- |
 | output   | String  | Output directory (relative to the path of ZModel)                                        | Yes     |         |
 | target   | String  | Target framework to generate for. Choose from "react", "vue", "svelte", "angular".              | Yes     |         |
-| version  | String  | Version of TanStack Query to generate for. Choose from "v4" and "v5". Angular supports only "v5"                    | No      | v5      |
+| version  | String  | Version of TanStack Query to generate for. Choose from "v4" and "v5". Target "angular" only works with "v5".                    | No      | v5      |
 | portable | Boolean | Include TypeScript types needed to compile the generated code in the output directory. Useful when you output into another project that doesn't reference Prisma and ZenStack. You'll still need to install the "@zenstackhq/tanstack-query" package in that project. | No      | false   |
 
 :::info

--- a/docs/reference/plugins/tanstack-query.mdx
+++ b/docs/reference/plugins/tanstack-query.mdx
@@ -38,6 +38,10 @@ npm install --save-dev @zenstackhq/tanstack-query
 | version  | String  | Version of TanStack Query to generate for. Choose from "v4" and "v5". Angular supports only "v5"                    | No      | v5      |
 | portable | Boolean | Include TypeScript types needed to compile the generated code in the output directory. Useful when you output into another project that doesn't reference Prisma and ZenStack. You'll still need to install the "@zenstackhq/tanstack-query" package in that project. | No      | false   |
 
+:::info
+Angular support is contributed by [@ScriptType](https://github.com/ScriptType).
+:::
+
 ### Hooks Signature
 
 The generated hooks have the following signature convention.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an informational note in the TanStack Query plugin docs acknowledging Angular support credit to ScriptType.
  * Placed the note after the “portable” option for clearer context.
  * Change is purely presentational with no impact on code, APIs, types, or runtime behavior.
  * Improves transparency and attribution within the documentation without altering existing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->