### PR TITLE
pageSize also acts as the maximum for "limit"

### DIFF
--- a/docs/reference/server-adapters/api-handlers/rest.mdx
+++ b/docs/reference/server-adapters/api-handlers/rest.mdx
@@ -82,7 +82,7 @@ The factory function accepts an options object with the following fields:
 
 - pageSize
 
-  Optional. A `number` field representing the default page size for listing resources and relationships. Defaults to 100. Set to Infinity to disable pagination.
+  Optional. A `number` field representing the default page size for listing resources and relationships. This value also determines the maximum `limit` value in an API call. Defaults to 100. Set to Infinity to disable pagination.
 
 - modelNameMapping
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pagination behavior for REST API handlers: the default pageSize also serves as the maximum allowed limit value in API requests.
  * Updated reference text to reduce ambiguity between pageSize and limit parameters and how they interact.
  * Improved guidance helps users configure pagination consistently and troubleshoot unexpected limiting.
  * No functional changes to the API or runtime behavior; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->