### PR TITLE
Rename RPCHandler to RPCApiHandler in customization guide

### DIFF
--- a/docs/the-complete-guide/part3/4-customization.md
+++ b/docs/the-complete-guide/part3/4-customization.md
@@ -47,7 +47,7 @@ app.use('/api/rpc-custom', async (req: Request, res: Response) => {
     const url = req.protocol + '://' + req.get('host') + req.originalUrl;
     const searchParams = new URL(url).searchParams;
     const query = Object.fromEntries(searchParams);
-    const handler = RPCHandler();
+    const handler = RPCApiHandler();
 
     const { status, body } = await handler({
         method: req.method,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the Custom Server Adapter guide to reflect the correct handler usage in examples, improving accuracy and alignment with current behavior.
  - Clarified that request routing, query extraction, and response handling remain unchanged; only the handler instantiation in examples has been adjusted.
  - Aims to reduce confusion for developers implementing custom adapters, with no impact on application behavior or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->