### PR TITLE
`currentModel` renamed to `modelAlias` in computed-fields.md

### DIFF
--- a/versioned_docs/version-3.x/orm/computed-fields.md
+++ b/versioned_docs/version-3.x/orm/computed-fields.md
@@ -47,7 +47,7 @@ const db = new ZenStackClient(schema, {
 });
 ```
 
-The computed field callback is also passed with a second `context` argument containing other useful information related to the current query. For example, you can use the `currentModel` property to refer to the containing model and use it to qualify field names in case of conflicts.
+The computed field callback is also passed with a second `context` argument containing other useful information related to the current query. For example, you can use the `modelAlias` property to refer to the containing model and use it to qualify field names in case of conflicts.
 
 ```ts
 import { sql } from 'kysely';
@@ -56,11 +56,11 @@ const db = new ZenStackClient(schema, {
   ...
   computedFields: {
     User: {
-      postCount: (eb, { currentModel }) => 
+      postCount: (eb, { modelAlias }) => 
         eb.selectFrom('Post')
-          // the `currentModel` context property gives you a name that you can
+          // the `modelAlias` context property gives you a name that you can
           // use to address the containing model (here `User`) at runtime
-          .whereRef('Post.authorId', '=', sql.ref(currentModel, 'id'))
+          .whereRef('Post.authorId', '=', sql.ref(modelAlias, 'id'))
           .select(({fn}) => fn.countAll<number>().as('count')),
     },
   },


### PR DESCRIPTION
Following this change:
https://github.com/zenstackhq/zenstack-v3/pull/255