### PR TITLE
add rest api sparse fieldsets

### DIFF
--- a/docs/reference/server-adapters/api-handlers/rest.mdx
+++ b/docs/reference/server-adapters/api-handlers/rest.mdx
@@ -622,9 +622,9 @@ When including related resources, the response data takes the form of [Compound 
 
 #### Sparse Fieldsets
 
-You can use the `fields[type]` query parameter to only include specified fields in the response. The value of the parameter is a comma-separated list of fields names.
+You can use the `fields[type]` query parameter to only include specified fields in the response. The value of the parameter is a comma-separated list of field names.
 
-See the JSON:API specification for more details [Sparse Fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets) and thier [Examples](https://jsonapi.org/examples/#sparse-fieldsets)
+See the JSON:API specification for more details [Sparse Fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets) and their [Examples](https://jsonapi.org/examples/#sparse-fieldsets)
 
 ##### Examples
 
@@ -637,7 +637,7 @@ See the JSON:API specification for more details [Sparse Fieldsets](https://jsona
 1. Also works with includes or relationships
 
     ```ts
-    GET /api/post?include=author&fields[post]=title,viewCount?fields[author]=email
+    GET /api/post?include=author&fields[post]=title,viewCount&fields[author]=email
     ```
 
 ### Creating a resource

--- a/docs/reference/server-adapters/api-handlers/rest.mdx
+++ b/docs/reference/server-adapters/api-handlers/rest.mdx
@@ -620,6 +620,26 @@ When including related resources, the response data takes the form of [Compound 
     GET /api/post?include=author,comments
     ```
 
+#### Sparse Fieldsets
+
+You can use the `fields[type]` query parameter to only include specified fields in the response. The value of the parameter is a comma-separated list of fields names.
+
+See the JSON:API specification for more details [Sparse Fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets) and thier [Examples](https://jsonapi.org/examples/#sparse-fieldsets)
+
+##### Examples
+
+1. Simple select
+
+    ```ts
+    GET /api/post?fields[post]=title,viewCount
+    ```
+
+1. Also works with includes or relationships
+
+    ```ts
+    GET /api/post?include=author&fields[post]=title,viewCount?fields[author]=email
+    ```
+
 ### Creating a resource
 
 A new resource can be created using the following endpoint:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Sparse Fieldsets" section to the REST API reference.
  * Describes using the fields[type] query parameter to request specific fields per resource type.
  * Provides two practical examples, including combining include with field restrictions.
  * Links to the JSON:API sparse fieldsets specification for further guidance.
  * Clarifies that no code or public API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->