### PR TITLE
Update TypeScript plugin documentation

### DIFF
--- a/versioned_docs/version-3.x/reference/plugins/typescript.md
+++ b/versioned_docs/version-3.x/reference/plugins/typescript.md
@@ -8,6 +8,8 @@ description: Generating TypeScript code from ZModel
 
 The `@core/typescript` plugin generates TypeScript code from ZModel. The generated code is used to access the schema at runtime, as well as type declarations at development time.
 
+**Note:** This plugin runs automatically when you execute `zenstack generate`, even if not explicitly declared in your schema. You only need to declare it if you want to customize its options.
+
 ## Options
 
 - `output`: Specifies the output directory for the generated TypeScript code. If a relative path is provided, it will be resolved relative to the ZModel schema.


### PR DESCRIPTION
Added note about automatic execution of the TypeScript plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Clarified that the TypeScript plugin runs automatically during generation and doesn’t require explicit schema declaration unless you need to customize options.
  * Updated guidance on when to include plugin configuration to align with default behavior.
  * No behavioral changes; existing workflows remain unaffected. This clarification aims to reduce setup confusion and set clear expectations for out-of-the-box operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->