### PR TITLE
doc: add Fluent API to Prisma migration compatibility table

### DIFF
--- a/docs/migrate-prisma.md
+++ b/docs/migrate-prisma.md
@@ -289,3 +289,4 @@ Here's a list of Prisma features that are not supported in ZenStack v3:
 | [Client Extensions](https://www.prisma.io/docs/orm/prisma-client/client-extensions) | No | Replaced with ZenStack runtime plugins |
 | [Full-Text Search](https://www.prisma.io/docs/orm/prisma-client/queries/full-text-search) | Yes | |
 | [Comparing Columns](https://www.prisma.io/docs/orm/reference/prisma-client-reference#compare-columns-in-the-same-table) | Yes | |
+| [Fluent API](https://www.prisma.io/docs/v6/orm/prisma-client/queries/relation-queries#fluent-api) | TBD | |


### PR DESCRIPTION
## Summary
- Adds Fluent API row to the Prisma features compatibility table in the migration guide, marked as TBD

## Test plan
- [ ] Verify the table renders correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide to reflect Fluent API feature support status in ZenStack v3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->