### PR TITLE
doc: add DateTime to scalar types list in data-field reference

### DIFF
--- a/docs/reference/zmodel/data-field.md
+++ b/docs/reference/zmodel/data-field.md
@@ -38,6 +38,7 @@ type Type {
     -   BigInt
     -   Float
     -   Decimal
+    -   DateTime
     -   Json
     -   Bytes
     -   Unsupported


### PR DESCRIPTION
## Summary
- Adds missing `DateTime` scalar type to the list in the ZModel data field reference docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated field type reference documentation to include `DateTime` as a supported scalar field type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->