### PR TITLE
doc: remove unnecessary endpoint option from RPC OAPI Express example

### DIFF
--- a/docs/service/openapi/rpc.md
+++ b/docs/service/openapi/rpc.md
@@ -41,7 +41,7 @@ import { schema } from '~/zenstack/schema';
 import { RPCApiHandler } from '@zenstackhq/server/api';
 
 const app = express();
-const handler = new RPCApiHandler({ schema, endpoint: 'http://localhost:3000/api' });
+const handler = new RPCApiHandler({ schema });
 
 // Serve the OpenAPI spec
 app.get('/api/openapi.json', async (_req, res) => {


### PR DESCRIPTION
## Summary

- Removes the `endpoint` option from the `RPCApiHandler` constructor in the Serving the Spec Express example in `docs/service/openapi/rpc.md`. The `endpoint` option is not required for `generateSpec()` to work.

## Test plan

- [ ] Verify `docs/service/openapi/rpc.md` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)