### PR TITLE
chore: rewrite /framer path to Framer app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,15 @@
 {
     "trailingSlash": false,
+    "rewrites": [
+        {
+            "source": "/framer",
+            "destination": "https://detailed-costs-055147.framer.app/"
+        },
+        {
+            "source": "/framer/:path*",
+            "destination": "https://detailed-costs-055147.framer.app/:path*"
+        }
+    ],
     "redirects": [
         {
             "source": "/docs/3.x",


### PR DESCRIPTION
## Summary

Adds Vercel `rewrites` rules so `/framer` and everything under `/framer/*` serve content from the Framer app (`https://detailed-costs-055147.framer.app/`) without changing the visible URL.

## Changes

- `vercel.json`: rewrite `/framer` → Framer app root
- `vercel.json`: rewrite `/framer/:path*` → Framer app sub-paths (preserves the path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)