### PR TITLE
docs: Update links for tanstack-query full-stack samples

### DIFF
--- a/docs/service/client-sdk/tanstack-query/index.md
+++ b/docs/service/client-sdk/tanstack-query/index.md
@@ -896,12 +896,12 @@ The following live demo shows how to use the query hooks in a React SPA.
 
 #### Next.js
 
-[https://github.com/zenstackhq/zenstack-v3/tree/main/samples/next.js](https://github.com/zenstackhq/zenstack-v3/tree/main/samples/next.js)
+[https://github.com/zenstackhq/zenstack/tree/main/samples/next.js](https://github.com/zenstackhq/zenstack/tree/main/samples/next.js)
 
 #### Nuxt
 
-[https://github.com/zenstackhq/zenstack-v3/tree/main/samples/nuxt](https://github.com/zenstackhq/zenstack-v3/tree/main/samples/nuxt)
+[https://github.com/zenstackhq/zenstack/tree/main/samples/nuxt](https://github.com/zenstackhq/zenstack/tree/main/samples/nuxt)
 
 #### SvelteKit
 
-[https://github.com/zenstackhq/zenstack-v3/tree/main/samples/sveltekit](https://github.com/zenstackhq/zenstack-v3/tree/main/samples/sveltekit)
+[https://github.com/zenstackhq/zenstack/tree/main/samples/sveltekit](https://github.com/zenstackhq/zenstack/tree/main/samples/sveltekit)


### PR DESCRIPTION
previous links pointed to https://github.com/zenstackhq/zenstack-v3/ which is now archived and outdated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Full-Stack Samples documentation links to reference the current repository version for Next.js, Nuxt, and SvelteKit sample projects, ensuring users access the latest available resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack-docs/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->