### PR TITLE
doc: document @@delegateMap attribute

### DIFF
--- a/docs/orm/polymorphism.md
+++ b/docs/orm/polymorphism.md
@@ -5,6 +5,7 @@ description: Polymorphic models
 
 import ZenStackVsPrisma from '../_components/ZenStackVsPrisma';
 import StackBlitzGithub from '@site/src/components/StackBlitzGithub';
+import AvailableSince from '../_components/AvailableSince';
 
 # Polymorphic Models
 
@@ -25,6 +26,78 @@ The ORM query API hides all the complexity of managing polymorphic models for yo
 - When creating a concrete model entity, its base entity is automatically created.
 - When querying a base entity, the ORM fetches the associated concrete entity and merges the results.
 - When deleting a base or concrete entity, the ORM automatically deletes the counterpart entity.
+
+## Customizing the discriminator value
+
+<AvailableSince version="v3.7.1" />
+
+By default, when the ORM creates a concrete entity, it stores the concrete model's **name** in the base model's discriminator field. For instance, given the schema below, creating a `Video` writes `"Video"` to `Content.type`, and creating an `Image` writes `"Image"`.
+
+```zmodel
+model Content {
+    id   Int    @id
+    type String
+    @@delegate(type)
+}
+
+model Video extends Content { url String }
+model Image extends Content { data Bytes }
+```
+
+If the model names don't match the values you want to store, you can override the value with the `@@delegateMap` attribute on each concrete model.
+
+### String discriminator
+
+When the discriminator field is a `String`, pass a string literal to `@@delegateMap`:
+
+```zmodel
+model Content {
+    id   Int    @id
+    type String
+    @@delegate(type)
+}
+
+model Video extends Content {
+    url String
+    // highlight-next-line
+    @@delegateMap("video")
+}
+
+model Image extends Content {
+    data Bytes
+    // highlight-next-line
+    @@delegateMap("image")
+}
+```
+
+### Enum discriminator
+
+When the discriminator field is an enum, pass an enum member to `@@delegateMap`. The member must come from the same enum as the discriminator field:
+
+```zmodel
+enum AssetKind {
+    ASSET_KIND_VIDEO
+    ASSET_KIND_IMAGE
+}
+
+model Asset {
+    id   Int       @id
+    type AssetKind
+    @@delegate(type)
+}
+
+model Video extends Asset {
+    url String
+    // highlight-next-line
+    @@delegateMap(ASSET_KIND_VIDEO)
+}
+
+model Image extends Asset {
+    data Bytes
+    // highlight-next-line
+    @@delegateMap(ASSET_KIND_IMAGE)
+}
+```
 
 ## Samples
 

--- a/docs/orm/polymorphism.md
+++ b/docs/orm/polymorphism.md
@@ -114,17 +114,6 @@ if (content.type === 'video') {
 }
 ```
 
-For an enum discriminator, narrow against the enum member instead (e.g., `asset.type === 'ASSET_KIND_VIDEO'`).
-
-### Validation rules
-
-The ZModel compiler enforces the following at the schema boundary:
-
-- `@@delegateMap` is only valid on a model that extends a delegate base.
-- A model may include at most one `@@delegateMap` attribute.
-- The value type must match the discriminator field: a string literal for a `String` discriminator, an enum member for an enum discriminator (and the member must belong to the discriminator's enum).
-- All concrete models that share the same delegate base must end up with distinct discriminator values. Without `@@delegateMap`, the model name is used — so a mapped value of `"Image"` would collide with a sibling `Image` model that has no `@@delegateMap`.
-
 ## Samples
 
 The schema used in the sample involves a base model and three concrete models:

--- a/docs/orm/polymorphism.md
+++ b/docs/orm/polymorphism.md
@@ -99,6 +99,32 @@ model Image extends Asset {
 }
 ```
 
+### TypeScript narrowing
+
+The discriminator value flows into the result type as a string literal (or enum member), so a check on the base field narrows the result to the matching concrete model:
+
+```ts
+const content = await client.content.findUniqueOrThrow({ where: { id: 1 } });
+if (content.type === 'video') {
+    // narrowed to Video — `url` is available
+    console.log(content.url);
+} else if (content.type === 'image') {
+    // narrowed to Image — `data` is available
+    console.log(content.data);
+}
+```
+
+For an enum discriminator, narrow against the enum member instead (e.g., `asset.type === 'ASSET_KIND_VIDEO'`).
+
+### Validation rules
+
+The ZModel compiler enforces the following at the schema boundary:
+
+- `@@delegateMap` is only valid on a model that extends a delegate base.
+- A model may include at most one `@@delegateMap` attribute.
+- The value type must match the discriminator field: a string literal for a `String` discriminator, an enum member for an enum discriminator (and the member must belong to the discriminator's enum).
+- All concrete models that share the same delegate base must end up with distinct discriminator values. Without `@@delegateMap`, the model name is used — so a mapped value of `"Image"` would collide with a sibling `Image` model that has no `@@delegateMap`.
+
 ## Samples
 
 The schema used in the sample involves a base model and three concrete models:

--- a/docs/reference/zmodel/attribute.md
+++ b/docs/reference/zmodel/attribute.md
@@ -359,6 +359,20 @@ _Params_:
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | discriminator | A `String` or `enum` field in the same model used to store the name of the concrete model that inherit from this base model. |
 
+### @@delegateMap
+
+```zmodel
+attribute @@delegateMap(_ value: Any)
+```
+
+Maps a delegate sub-model to a specific discriminator value. Applied to a concrete model that extends a delegate base. If omitted, the sub-model's name is used as the discriminator value by default. See [Customizing the discriminator value](../../orm/polymorphism.md#customizing-the-discriminator-value).
+
+_Params_:
+
+| Name  | Description                                                                                                                                          |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| value | A string literal (when the discriminator is `String`) or an enum member (when the discriminator is an enum, and must belong to the same enum type). |
+
 ### @@meta
 
 ```zmodel


### PR DESCRIPTION
## Summary
- Document the new `@@delegateMap` attribute (introduced in zenstack v3.7.1 via [zenstackhq/zenstack#2676](https://github.com/zenstackhq/zenstack/pull/2676)) for customizing the discriminator value of polymorphic sub-models.
- Add a "Customizing the discriminator value" section to `docs/orm/polymorphism.md` covering the default behavior, string-discriminator and enum-discriminator usage, TS narrowing, and validation rules. Marked `<AvailableSince version="v3.7.1" />`.
- Add a reference entry for `@@delegateMap` next to `@@delegate` in `docs/reference/zmodel/attribute.md`.

## Test plan
- [ ] `pnpm start` and verify the new section renders correctly on `/docs/orm/polymorphism`
- [ ] Verify the new reference entry renders on `/docs/reference/zmodel/attribute` and that the cross-link to the ORM section works
- [ ] `pnpm build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide on customizing discriminator values in polymorphism, including examples for String and enum field types.
  * Documented the `@@delegateMap` attribute, explaining how to override default discriminator value mappings in delegate models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack-docs/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->