### PR TITLE
docs: `@phone` and `isPhone`

### DIFF
--- a/docs/reference/zmodel/input-validation.md
+++ b/docs/reference/zmodel/input-validation.md
@@ -63,6 +63,14 @@ All field-level attributes have a `message` parameter that allows you to provide
 
         Requires a string field to be a valid email address.
 
+    - `@phone`
+
+        ```zmodel
+        @phone(_ message: String?)
+        ```
+
+        Requires a string field to be a valid E.164 phone number.
+
     - `@url`
   
         ```zmodel
@@ -194,6 +202,14 @@ All field-level attributes have a `message` parameter that allows you to provide
     ```
 
   Checks if a string field is a valid email address.
+
+- `isPhone()`
+
+    ```zmodel
+    function isPhone(field: String): Boolean {}
+    ```
+
+  Checks if a string field is a valid E.164 phone number.
 
 - `isUrl()`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ZModel input validation reference documentation with new `@phone` attribute for string field validation, supporting E.164 phone number format
  * Added documentation for `isPhone()` helper utility function to programmatically validate E.164 phone numbers on string fields

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack-docs/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->