### PR TITLE
docs: document @phone validation attribute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ The site has two doc versions:
 
 When adding documentation that applies only to v3, add it to `docs/`. The v2.x content is archived and should rarely need changes.
 
+When documenting a new feature, attribute, function, option, or API surface, mark it with the `<AvailableSince version="vX.Y.Z" />` component (from `docs/_components/AvailableSince.tsx`) so readers know which release first shipped it. Place the tag immediately under the heading or bullet that introduces the feature, and add `import AvailableSince from '<relative-path>/_components/AvailableSince';` at the top of the doc if it isn't already imported. See [docs/utilities/zod.md](docs/utilities/zod.md) and [docs/reference/zmodel/input-validation.md](docs/reference/zmodel/input-validation.md) for examples.
+
 ### Key Configuration
 
 - `docusaurus.config.js` — Main site config: navbar, footer, Algolia search, Mermaid diagrams, Google Tag Manager

--- a/docs/reference/zmodel/input-validation.md
+++ b/docs/reference/zmodel/input-validation.md
@@ -2,6 +2,8 @@
 sidebar_position: 11
 ---
 
+import AvailableSince from '../../_components/AvailableSince';
+
 # Input Validation
 
 This document describes the attributes and functions available for input validation in ZModel. See [Input Validation](../../orm/validation.md) for more details on how to use them.
@@ -70,6 +72,16 @@ All field-level attributes have a `message` parameter that allows you to provide
         ```
 
         Requires a string field to be a valid URL.
+
+    - `@phone`
+
+        <AvailableSince version="v3.7.2" />
+
+        ```zmodel
+        @phone(_ message: String?)
+        ```
+
+        Requires a string field to be a valid [E.164](https://en.wikipedia.org/wiki/E.164) phone number (e.g. `+15555555555`).
 
     - `@datetime`
   
@@ -202,6 +214,16 @@ All field-level attributes have a `message` parameter that allows you to provide
     ```
 
   Checks if a string field is a valid URL.
+
+- `isPhone()`
+
+    <AvailableSince version="v3.7.2" />
+
+    ```zmodel
+    function isPhone(field: String): Boolean {}
+    ```
+
+  Checks if a string field is a valid [E.164](https://en.wikipedia.org/wiki/E.164) phone number.
 
 - `isDateTime()`
 


### PR DESCRIPTION
## Summary

- Add reference docs for the `@phone` field attribute and `isPhone()` validation function (introduced in v3.7.2 via zenstackhq/zenstack#2672). Both validate [E.164](https://en.wikipedia.org/wiki/E.164) phone numbers.
- Tag both with `<AvailableSince version="v3.7.2" />` and import the component at the top of [docs/reference/zmodel/input-validation.md](../blob/docs/phone-validation/docs/reference/zmodel/input-validation.md).
- Add a CLAUDE.md note so future docs for new features remember to include `<AvailableSince />`.

## Test plan

- [ ] `pnpm start` and visit `/docs/reference/zmodel/input-validation` — confirm `@phone` and `isPhone()` sections render with the version badge.
- [ ] `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive phone number validation for input validation, including a field-level validation attribute with customizable error messages and a dedicated validation function.

* **Documentation**
  * Updated input validation reference documentation with complete guidance on newly available phone number validation features and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->