### PR TITLE
docs: move Quick Start to top-level after Prerequisite

### DIFF
--- a/docs/community-packages.md
+++ b/docs/community-packages.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: Community Packages
 ---
 

--- a/docs/migrate-prisma.md
+++ b/docs/migrate-prisma.md
@@ -1,6 +1,6 @@
 ---
 description: How to migrate from a Prisma project to ZenStack v3
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 import PackageInstall from './_components/PackageInstall';

--- a/docs/migrate-v2.md
+++ b/docs/migrate-v2.md
@@ -1,6 +1,6 @@
 ---
 description: How to migrate from a ZenStack v2 project to v3
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 import PackageInstall from './_components/PackageInstall';

--- a/docs/modeling/_category_.yml
+++ b/docs/modeling/_category_.yml
@@ -1,4 +1,4 @@
-position: 3
+position: 4
 label: Data Modeling
 collapsible: true
 collapsed: true

--- a/docs/orm/_category_.yml
+++ b/docs/orm/_category_.yml
@@ -1,4 +1,4 @@
-position: 4
+position: 5
 label: ORM
 collapsible: true
 collapsed: true

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,13 +1,13 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 description: Quick start guide
 ---
 
 import StackBlitzGithub from '@site/src/components/StackBlitzGithub';
-import ZModelStarter from '../_components/_zmodel-starter.md';
-import PackageInstall from '../_components/PackageInstall';
-import PackageExec from '../_components/PackageExec';
-import PackageDlx from '../_components/PackageDlx';
+import ZModelStarter from './_components/_zmodel-starter.md';
+import PackageInstall from './_components/PackageInstall';
+import PackageExec from './_components/PackageExec';
+import PackageDlx from './_components/PackageDlx';
 
 # Quick Start
 
@@ -59,7 +59,7 @@ You can also always configure a project manually with the following steps:
 
 :::info
 
-By default, ZenStack CLI loads the schema from `zenstack/schema.zmodel`. You can change this by passing the `--schema` option. TypeScript files are by default generated to the same directory as the schema file. You can change this by passing the `--output` option. The default settings can also be changed as explained in the [CLI reference](../reference/cli#overriding-default-options).
+By default, ZenStack CLI loads the schema from `zenstack/schema.zmodel`. You can change this by passing the `--schema` option. TypeScript files are by default generated to the same directory as the schema file. You can change this by passing the `--output` option. The default settings can also be changed as explained in the [CLI reference](./reference/cli#overriding-default-options).
 
 You can choose to either commit the generated TypeScript files to your source control (recommended), or add them to `.gitignore` and generate them on the fly in your CI/CD pipeline.
 

--- a/docs/recipe/_category_.yml
+++ b/docs/recipe/_category_.yml
@@ -1,4 +1,4 @@
-position: 8
+position: 9
 label: Recipes
 collapsible: true
 collapsed: true

--- a/docs/reference/_category_.yml
+++ b/docs/reference/_category_.yml
@@ -1,4 +1,4 @@
-position: 9
+position: 10
 label: Reference
 collapsible: true
 collapsed: true

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: Sample Projects
 ---
 

--- a/docs/service/_category_.yml
+++ b/docs/service/_category_.yml
@@ -1,4 +1,4 @@
-position: 5
+position: 6
 label: Query as a Service
 collapsible: true
 collapsed: true

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Studio
 ---
 

--- a/docs/utilities/_category_.yml
+++ b/docs/utilities/_category_.yml
@@ -1,4 +1,4 @@
-position: 6
+position: 7
 label: Utilities
 collapsible: true
 collapsed: true


### PR DESCRIPTION
## Summary

Relocates the **Quick Start** guide from the ORM section to a top-level doc, positioned right after **Prerequisite** in the sidebar.

## Changes

- `git mv docs/orm/quick-start.md docs/quick-start.md`
- Set its `sidebar_position` to `3` and fixed paths for the new location:
  - imports `../_components/…` → `./_components/…`
  - CLI reference link `../reference/cli` → `./reference/cli`
- Shifted the categories/docs previously at positions 3–13 down by one (modeling→4, orm→5, service→6, utilities→7, studio→8, recipe→9, reference→10, community-packages→11, samples→12, migrate-prisma→13, migrate-v2→14)

Resulting order: Overview → Prerequisite → **Quick Start** → Data Modeling → ORM → …

No internal markdown links referenced the old `/orm/quick-start` route, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized documentation sidebar page ordering across multiple guides.
  * Updated internal documentation reference paths and component imports for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->