### PR TITLE
docs: add recipe for setting up AI agents

### DIFF
--- a/docs/community-packages.md
+++ b/docs/community-packages.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: Community Packages
 ---
 

--- a/docs/migrate-prisma.md
+++ b/docs/migrate-prisma.md
@@ -1,6 +1,6 @@
 ---
 description: How to migrate from a Prisma project to ZenStack v3
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 import PackageInstall from './_components/PackageInstall';

--- a/docs/migrate-v2.md
+++ b/docs/migrate-v2.md
@@ -1,6 +1,6 @@
 ---
 description: How to migrate from a ZenStack v2 project to v3
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 import PackageInstall from './_components/PackageInstall';

--- a/docs/modeling/_category_.yml
+++ b/docs/modeling/_category_.yml
@@ -1,4 +1,4 @@
-position: 3
+position: 4
 label: Data Modeling
 collapsible: true
 collapsed: true

--- a/docs/orm/_category_.yml
+++ b/docs/orm/_category_.yml
@@ -1,4 +1,4 @@
-position: 4
+position: 5
 label: ORM
 collapsible: true
 collapsed: true

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,13 +1,13 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 description: Quick start guide
 ---
 
 import StackBlitzGithub from '@site/src/components/StackBlitzGithub';
-import ZModelStarter from '../_components/_zmodel-starter.md';
-import PackageInstall from '../_components/PackageInstall';
-import PackageExec from '../_components/PackageExec';
-import PackageDlx from '../_components/PackageDlx';
+import ZModelStarter from './_components/_zmodel-starter.md';
+import PackageInstall from './_components/PackageInstall';
+import PackageExec from './_components/PackageExec';
+import PackageDlx from './_components/PackageDlx';
 
 # Quick Start
 
@@ -59,7 +59,7 @@ You can also always configure a project manually with the following steps:
 
 :::info
 
-By default, ZenStack CLI loads the schema from `zenstack/schema.zmodel`. You can change this by passing the `--schema` option. TypeScript files are by default generated to the same directory as the schema file. You can change this by passing the `--output` option. The default settings can also be changed as explained in the [CLI reference](../reference/cli#overriding-default-options).
+By default, ZenStack CLI loads the schema from `zenstack/schema.zmodel`. You can change this by passing the `--schema` option. TypeScript files are by default generated to the same directory as the schema file. You can change this by passing the `--output` option. The default settings can also be changed as explained in the [CLI reference](./reference/cli#overriding-default-options).
 
 You can choose to either commit the generated TypeScript files to your source control (recommended), or add them to `.gitignore` and generate them on the fly in your CI/CD pipeline.
 

--- a/docs/recipe/_category_.yml
+++ b/docs/recipe/_category_.yml
@@ -1,4 +1,4 @@
-position: 8
+position: 9
 label: Recipes
 collapsible: true
 collapsed: true

--- a/docs/recipe/ai-agents.md
+++ b/docs/recipe/ai-agents.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 7
+---
+
+# Setting Up AI Agents
+
+AI coding agents like Claude Code, Cursor, and GitHub Copilot can be tremendously productive with ZenStack — but only if they actually understand how it works. This guide shows you how to set up your agents so they generate correct, idiomatic ZenStack V3 code.
+
+There are two complementary pieces to the setup:
+
+1. **Skills** — installable, task-specific instructions that teach the agent how to perform common ZenStack workflows.
+2. **Context7 MCP** — a documentation lookup tool that gives the agent access to the always-current ZenStack docs.
+
+## Installing ZenStack Skills
+
+[Agent Skills](https://www.skills.sh/) are structured instructions that teach AI agents how to work with a specific technology. ZenStack publishes an official skill collection at [zenstackhq/skills](https://github.com/zenstackhq/skills), covering schema modeling, access control, querying, migrations, CRUD server generation, and more.
+
+The easiest way to install them is with the [`skills.sh`](https://www.skills.sh/) CLI. Run the following command in your project's root directory and use the `--all` flag to install every ZenStack skill at once:
+
+```bash
+npx skills add zenstackhq/skills --all
+```
+
+The CLI auto-detects the coding agents you have installed (Claude Code, Cursor, Copilot, and many others) and sets up the skills for each of them.
+ 
+:::tip
+You can also install globally so the skills are available across all your projects:
+
+```bash
+npx skills add zenstackhq/skills --all -g
+```
+:::
+
+To preview what's included before installing, run:
+
+```bash
+npx skills add zenstackhq/skills --list
+```
+
+:::info
+ZenStack and its skills evolve over time, so update your installed skills periodically to keep your agents in sync with new features and best practices:
+
+```bash
+npx skills update
+```
+:::
+
+## Using Context7 for Live Documentation
+
+Skills give the agent procedural know-how, but for the most up-to-date API details, configuration options, and edge cases, the agent should be able to consult the ZenStack documentation directly. The entire ZenStack documentation site is indexed by [Context7](https://context7.com/) under the [`websites/zenstack_dev`](https://context7.com/websites/zenstack_dev) project.
+
+Context7 is available as an [MCP](https://modelcontextprotocol.io/) server. Once it's connected, your agent can pull relevant documentation snippets on demand instead of relying on (potentially stale) training data. Refer to [Context7's installation guide](https://github.com/upstash/context7) to add the MCP server to your agent.
+
+Usually the agent will identify the correct Context7 project to use on its own. In case it picks the wrong one, you can explicitly point it at the `websites/zenstack_dev` library ID (the V3 documentation).
+
+## Telling Your Agent to Use Them
+
+Usually agents are smart enough to automatically utilize the installed skills and the Context7 documentation. However, it's more reliable to explicitly mention these resources in the project's memory. Most agents read project-level instruction files (`CLAUDE.md` for Claude Code, `AGENTS.md` for the broader convention) at the start of a session. Add a note there so the agent knows these resources exist and prefers them.
+
+For example, add the following to your `CLAUDE.md` or `AGENTS.md`:
+
+```markdown
+## Working With ZenStack
+
+This project uses ZenStack V3. When working on ZenStack-related tasks:
+
+- Use the installed ZenStack skills (schema modeling, access control,
+  querying, migrations, CRUD server, etc.) for guidance on the correct
+  patterns and APIs.
+- When you need authoritative API details or run into uncertainty, consult
+  the ZenStack documentation via the Context7 MCP server (the `websites/zenstack_dev`
+  project) rather than relying on prior knowledge — ZenStack V3 differs
+  significantly from V2.
+```
+
+With skills installed, Context7 connected, and your instruction file in place, your AI agent will have everything it needs to be a productive ZenStack collaborator.

--- a/docs/reference/_category_.yml
+++ b/docs/reference/_category_.yml
@@ -1,4 +1,4 @@
-position: 9
+position: 10
 label: Reference
 collapsible: true
 collapsed: true

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: Sample Projects
 ---
 

--- a/docs/service/_category_.yml
+++ b/docs/service/_category_.yml
@@ -1,4 +1,4 @@
-position: 5
+position: 6
 label: Query as a Service
 collapsible: true
 collapsed: true

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Studio
 ---
 

--- a/docs/utilities/_category_.yml
+++ b/docs/utilities/_category_.yml
@@ -1,4 +1,4 @@
-position: 6
+position: 7
 label: Utilities
 collapsible: true
 collapsed: true


### PR DESCRIPTION
## Summary

Adds a new recipe, **Setting Up AI Agents**, explaining how to make AI coding agents (Claude Code, Cursor, Copilot, etc.) work effectively with ZenStack V3.

The recipe covers:

- **Installing skills** — using the `skills.sh` CLI to install the official [zenstackhq/skills](https://github.com/zenstackhq/skills) collection (`npx skills add zenstackhq/skills --all`), with global install, `--list` preview, and a note on updating skills periodically via `npx skills update`.
- **Context7 MCP** — pointing agents at the `websites/zenstack_dev` Context7 project for always-current documentation.
- **Project memory** — adding a note to `CLAUDE.md` / `AGENTS.md` so agents reliably use the skills and Context7 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)