### PR TITLE
docs: add zenstack-replicas to community packages

### DIFF
--- a/docs/community-packages.md
+++ b/docs/community-packages.md
@@ -7,6 +7,10 @@ sidebar_label: Community Packages
 
 ZenStack plugins built by our awesome community members :heart:.
 
+- [zenstack-replicas](https://github.com/visualbravo/zenstack-replicas)
+
+    Distribute read operations across database replicas with round-robin load balancing for the ZenStack ORM. Made by [@sanny-io](https://github.com/sanny-io).
+
 - [zmodel-to-dart](https://pub.dev/packages/zmodel_to_dart)
 
     A Dart builder that generates DTO classes from .zmodel files. Made by [Israel Lins Albuquerque](https://github.com/israelins85).


### PR DESCRIPTION
Adds [zenstack-replicas](https://github.com/visualbravo/zenstack-replicas) to the Community Packages list — distributes read operations across database replicas with round-robin load balancing for the ZenStack ORM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the `zenstack-replicas` community package, which provides read operation distribution across database replicas with round-robin load balancing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->