### PR TITLE
docs: mark soft-delete plugin as preview

### DIFF
--- a/docs/reference/plugins/soft-delete.md
+++ b/docs/reference/plugins/soft-delete.md
@@ -3,10 +3,13 @@ sidebar_position: 4
 ---
 
 import AvailableSince from '../../_components/AvailableSince';
+import PreviewFeature from '../../_components/PreviewFeature';
 
 # @zenstackhq/plugin-soft-delete
 
 <AvailableSince version="v3.8.0" />
+
+<PreviewFeature name="Soft delete plugin" />
 
 The `@zenstackhq/plugin-soft-delete` plugin implements **soft delete** by intercepting Kysely queries at runtime. Instead of physically removing rows, delete operations mark them with a timestamp, and reads automatically exclude the marked rows.
 


### PR DESCRIPTION
Marks the `@zenstackhq/plugin-soft-delete` reference doc with a `<PreviewFeature />` badge to signal that the plugin is in preview and subject to breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the soft-delete plugin documentation to mark it as a preview feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->