### PR TITLE
docs: clarify omit is not a security feature

### DIFF
--- a/docs/orm/api/omit.md
+++ b/docs/orm/api/omit.md
@@ -13,6 +13,10 @@ The previous sections have shown how you can use `select` and `omit` clauses to 
 Please note that the omit settings only affect the ORM query APIs, but not the [Query Builder APIs](../query-builder). With query builder you'll need to explicitly specify the fields to select.
 :::
 
+:::warning
+Omit (at all three layers) is not a security feature. It's merely a convenient way to control the default set of fields returned during a query. Don't rely on it to protect sensitive data — use [access policies](../access-control) for that purpose.
+:::
+
 ## Schema-Level Omit
 
 You can use the `@omit` attribute in ZModel to mark fields to be omitted. Such fields will be omitted by default for all `ZenStackClient` instances and all queries.
@@ -71,7 +75,7 @@ const users = await db.user.findMany({
 });
 ```
 
-There might be scenarios where you don't want the query-level override feature. For example, when using `ZenStackClient` with the [Query as a Service](../../service), you may want to have certain fields always omitted for security reasons. In such cases, use the `allowQueryTimeOmitOverride` option to disable query-time overrides:
+There might be scenarios where you don't want the query-level override feature. For example, when using `ZenStackClient` with the [Query as a Service](../../service), you may want to have certain fields always omitted. In such cases, use the `allowQueryTimeOmitOverride` option to disable query-time overrides:
 
 ```ts
 const db = new ZenStackClient<Schema>({


### PR DESCRIPTION
Adds a warning callout to the omit docs clarifying that the omit feature (at all three layers — schema, client, and query) is not a security feature, but rather a convenient way to control the default set of fields returned during a query. Readers are pointed to access policies for protecting sensitive data.

Also removes the "for security reasons" phrasing from the `allowQueryTimeOmitOverride` section to stay consistent with this framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `omit` settings are not a security feature and should not be used to protect sensitive data.
  * Updated guidance on query-time omit overrides to better explain when always-hidden fields should remain omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->