### PR TITLE
docs(recipe): add NestJS + Swagger OpenAPI merge guide

### DIFF
--- a/docs/recipe/nestjs.md
+++ b/docs/recipe/nestjs.md
@@ -165,3 +165,140 @@ export class AppController {
 ```
 
 With this setup, all requests to `/api/*` will be handled by the ZenStack API handler, which performs the necessary CRUD operations with access control enforced. Refer to the [API handlers documentation](../service/api-handler/) for request and response formats and other details.
+
+### Sharing the Handler Across Thin Controllers
+
+A single catch-all controller is the simplest setup, but it makes it hard to attach per-resource NestJS features — guards, interceptors, rate limits, or Swagger decorators. An alternative is to wrap the handler in a service and forward from small, per-resource controllers:
+
+```ts title="src/db/resthandler.service.ts"
+import { Inject, Injectable } from '@nestjs/common';
+import { RestApiHandler } from '@zenstackhq/server/api';
+import type { Request, Response } from 'express';
+import { schema, type SchemaType } from '../../zenstack/schema';
+
+@Injectable()
+export class RestHandlerService {
+  private readonly apiHandler = new RestApiHandler<SchemaType>({
+    schema,
+    endpoint: 'http://localhost:3000/api',
+  });
+
+  constructor(@Inject('AUTH_DB') private readonly dbService: any) {}
+
+  async handleRequest(req: Request, res: Response) {
+    // Strip the controller's path prefix so the handler sees a resource-relative
+    // path (e.g. "post/1"), matching the catch-all example above.
+    const relativePath = req.path.replace(/^\/api\//, '');
+    const result = await this.apiHandler.handleRequest({
+      method: req.method,
+      path: relativePath,
+      query: req.query as Record<string, string | string[]>,
+      requestBody: req.body,
+      client: this.dbService,
+    });
+    res.status(result.status);
+    return result.body;
+  }
+}
+```
+
+```ts title="src/post/post.controller.ts"
+import { Controller, Get, Post, Req, Res } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
+import { RestHandlerService } from '../db/resthandler.service';
+
+@ApiTags('post')
+@Controller('post')
+export class PostController {
+  constructor(private readonly rest: RestHandlerService) {}
+
+  // Declaring the methods (rather than a single `@All`) lets you attach
+  // guards, Swagger decorators, and rate limits per operation while still
+  // delegating the actual work to the shared ZenStack handler.
+  @Get(['', '/:id'])
+  get(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    return this.rest.handleRequest(req, res);
+  }
+
+  @Post()
+  create(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    return this.rest.handleRequest(req, res);
+  }
+}
+```
+
+Each controller still delegates all CRUD work to the same handler, so there's no duplicated logic — the controllers exist only to carry NestJS metadata (guards, tags, decorators) for their resource.
+
+## Merging the OpenAPI Spec With NestJS Swagger
+
+The RESTful and RPC API handlers can [generate an OpenAPI spec](../service/openapi/restful.md) at runtime from your ZModel schema. When you also have hand-written NestJS controllers (custom actions, auth endpoints, or the thin delegating controllers above), you'll want a single Swagger UI that documents both. The trick is to generate each spec separately and merge their `paths` and `components`.
+
+Two details make the merge work:
+
+- **Path prefixes differ.** ZenStack paths are relative to the handler's `endpoint` (e.g. `/post/{id}`), while NestJS paths include the [global prefix](https://docs.nestjs.com/faq/global-prefix) (e.g. `/api/post/{id}`). Re-prefix the ZenStack paths before merging.
+- **Both contribute component schemas.** Keep ZenStack's resource/error schemas and NestJS's DTO schemas.
+
+```ts title="src/swagger.ts"
+import type { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule, type OpenAPIObject } from '@nestjs/swagger';
+import type { RestApiHandler } from '@zenstackhq/server/api';
+
+export async function setupSwagger(
+  app: INestApplication,
+  handler: RestApiHandler<any>,
+  prefix = 'api',
+) {
+  // 1. ZenStack's runtime spec. `respectAccessPolicies` prunes fields and
+  //    operations the anonymous/base role can't reach, so the published spec
+  //    matches what the API actually exposes.
+  const zenStackSpec = (await handler.generateSpec({
+    title: 'My API',
+    respectAccessPolicies: true,
+  })) as OpenAPIObject;
+
+  // 2. Re-prefix ZenStack paths ("/post/{id}" -> "/api/post/{id}") so they line
+  //    up with NestJS's global prefix.
+  const zenStackPaths = Object.fromEntries(
+    Object.entries(zenStackSpec.paths ?? {}).map(([path, config]) => [
+      `/${prefix}${path}`,
+      config,
+    ]),
+  );
+
+  // 3. NestJS spec from your decorated controllers.
+  const nestDocument = SwaggerModule.createDocument(
+    app,
+    new DocumentBuilder().setTitle('My API').build(),
+  );
+
+  // 4. Merge paths. Where a controller documents the same path+method as
+  //    ZenStack, the NestJS operation wins (it carries your guards, headers,
+  //    and hand-written descriptions); otherwise ZenStack fills it in.
+  const paths: OpenAPIObject['paths'] = { ...zenStackPaths };
+  for (const [path, operations] of Object.entries(nestDocument.paths ?? {})) {
+    paths[path] = { ...(paths[path] ?? {}), ...operations };
+  }
+
+  const merged: OpenAPIObject = {
+    ...nestDocument,
+    paths,
+    components: {
+      ...zenStackSpec.components,
+      ...nestDocument.components,
+      schemas: {
+        ...zenStackSpec.components?.schemas,
+        ...nestDocument.components?.schemas,
+      },
+    },
+  };
+
+  SwaggerModule.setup(prefix, app, merged);
+}
+```
+
+Call it from `main.ts` after the app is created (and after `app.setGlobalPrefix(prefix)`), passing the same handler instance your controllers use.
+
+:::tip Going further
+The merge step is plain object manipulation, so you can layer on whatever your API needs: merge response objects instead of overwriting them (to keep NestJS-declared headers on ZenStack operations), publish separate public vs. internal specs by filtering operations on a custom `x-*` extension, add security schemes, or prune component schemas that end up unreferenced after filtering. Because the ZenStack spec is regenerated from the schema on every boot, it never drifts from your data model.
+:::


### PR DESCRIPTION
## What

Extends the NestJS recipe (`docs/recipe/nestjs.md`) with two patterns for going beyond the basic catch-all handler, both drawn from a production ZenStack 3.x + NestJS app.

### Sharing the handler across thin controllers
Wrapping `RestApiHandler` in a service and forwarding from small, per-resource controllers, so guards, interceptors, rate limits, and Swagger decorators attach per resource while the delegation logic stays in one place.

### Merging the OpenAPI spec with @nestjs/swagger
A single Swagger UI that documents both the handler's schema-generated endpoints and hand-written NestJS controllers. Covers the two things that actually trip people up:
- **Path prefixes differ** — ZenStack paths are relative to the handler's `endpoint` (`/post/{id}`); NestJS paths carry the global prefix (`/api/post/{id}`). The helper re-prefixes ZenStack paths before merging.
- **Both contribute components** — merge `paths` (NestJS operation wins on conflict) and union `components.schemas`.

Uses `generateSpec({ respectAccessPolicies: true })` so the published spec matches what the API actually exposes, and closes with a "going further" tip pointing at response-header merging, public/internal filtering, and schema pruning.

## Why

The existing recipe stops at the `@All('/*path')` catch-all. There was no guidance on producing unified OpenAPI docs when a real app mixes schema-generated CRUD with custom NestJS endpoints — a common need, and easy to get the path-prefix/component merge subtly wrong.

## Open question: should some of this become shared code?

Parts of what this recipe documents by hand are generic enough to package, and I'd value maintainer input on whether/where that should land. The candidates split along a dependency line:

- **Framework-agnostic OpenAPI post-processing** (no `@nestjs/*` deps) — `pruneUnreferencedSchemas` (BFS over `$ref` chains to drop unreachable `components.schemas`), path re-prefixing, and REST query normalization + default-vs-max page size (working around `pageSize` being both the default *and* the hard ceiling). These would fit naturally in `api/rest` alongside `openapi.ts`, and would benefit any framework serving the spec — not just NestJS.
- **NestJS-coupled glue** (imports `@nestjs/swagger`) — the spec merge itself and an optional thin-controller helper. Can't live in core (no `@nestjs/*` deps there), so this would be a separate package.

Would you be open to taking the framework-agnostic helpers into `api/rest`? If a dedicated `@zenstackhq/server/nest` adapter is preferred instead, happy to scope that. Otherwise this stays a documentation-only contribution.

## Notes

- Docs-only change; no code or public API affected.
- Links to the existing `service/openapi/restful.md`; only touches the current (v3) recipe, not the versioned 2.x docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new NestJS guide showing how to reuse a shared API handler across multiple lightweight controllers.
  * Expanded Swagger documentation with an end-to-end setup for generating and merging OpenAPI output from ZenStack and NestJS.
  * Included a practical example for configuring Swagger with path prefix handling and document merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->