### PR TITLE
fix: open navbar logo home link in the same tab

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,6 +100,7 @@ const config = {
                     alt: 'ZenStack Logo',
                     src: 'img/new-logo.png',
                     href: 'pathname:///',
+                    target: '_self',
                 },
                 items: [
                     {


### PR DESCRIPTION
The navbar logo/title links to the landing page via `href: 'pathname:///'`. Docusaurus treats `pathname://` URLs as external, so the logo link defaulted to `target="_blank"` and opened the home page in a new tab. This adds an explicit `target: '_self'` so the logo navigates in the same tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)