### PR TITLE
fix: rewrite canonical URL of Framer-hosted homepage to zenstack.dev

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,7 +17,6 @@ export const config = { matcher: '/' };
 
 export default async function middleware(): Promise<Response | undefined> {
     try {
-        console.log('Fetching Framer landing page...');
         const upstream = await fetch(`${FRAMER_ORIGIN}/`, {
             headers: { accept: 'text/html' },
         });
@@ -29,9 +28,6 @@ export default async function middleware(): Promise<Response | undefined> {
 
         const html = await upstream.text();
         const rewritten = html.split(FRAMER_ORIGIN).join(CANONICAL_ORIGIN);
-        if (rewritten !== html) {
-            console.log('Rewrote Framer landing page HTML to canonical domain.');
-        }
 
         const headers = new Headers(upstream.headers);
         // the body was re-encoded, so the upstream encoding/length no longer apply

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,45 @@
+/**
+ * Vercel Edge Middleware.
+ *
+ * The `/` route is rewritten to the Framer-hosted landing page (see
+ * `vercel.json`), whose HTML declares `zenstack.framer.website` as the
+ * canonical/og:url. This middleware proxies the page and rewrites those
+ * URLs to `https://zenstack.dev` so search engines index the real domain.
+ *
+ * If anything goes wrong it returns `undefined`, falling through to the
+ * plain rewrite in `vercel.json` (unmodified page instead of an error).
+ */
+
+const FRAMER_ORIGIN = 'https://zenstack.framer.website';
+const CANONICAL_ORIGIN = 'https://zenstack.dev';
+
+export const config = { matcher: '/' };
+
+export default async function middleware(): Promise<Response | undefined> {
+    try {
+        console.log('Fetching Framer landing page...');
+        const upstream = await fetch(`${FRAMER_ORIGIN}/`, {
+            headers: { accept: 'text/html' },
+        });
+
+        const contentType = upstream.headers.get('content-type') ?? '';
+        if (!upstream.ok || !contentType.includes('text/html')) {
+            return undefined;
+        }
+
+        const html = await upstream.text();
+        const rewritten = html.split(FRAMER_ORIGIN).join(CANONICAL_ORIGIN);
+        if (rewritten !== html) {
+            console.log('Rewrote Framer landing page HTML to canonical domain.');
+        }
+
+        const headers = new Headers(upstream.headers);
+        // the body was re-encoded, so the upstream encoding/length no longer apply
+        headers.delete('content-encoding');
+        headers.delete('content-length');
+
+        return new Response(rewritten, { status: upstream.status, headers });
+    } catch {
+        return undefined;
+    }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,7 +21,7 @@ export default async function middleware(request: Request): Promise<Response | u
         // affect the HTML Framer serves (never cookie/host)
         const { search } = new URL(request.url);
         const requestHeaders = new Headers({ accept: 'text/html' });
-        for (const name of ['user-agent', 'accept-language']) {
+        for (const name of ['user-agent', 'accept-language', 'referer', 'x-forwarded-for']) {
             const value = request.headers.get(name);
             if (value) {
                 requestHeaders.set(name, value);

--- a/middleware.ts
+++ b/middleware.ts
@@ -15,11 +15,20 @@ const CANONICAL_ORIGIN = 'https://zenstack.dev';
 
 export const config = { matcher: '/' };
 
-export default async function middleware(): Promise<Response | undefined> {
+export default async function middleware(request: Request): Promise<Response | undefined> {
     try {
-        const upstream = await fetch(`${FRAMER_ORIGIN}/`, {
-            headers: { accept: 'text/html' },
-        });
+        // preserve the original query string; forward only headers that may
+        // affect the HTML Framer serves (never cookie/host)
+        const { search } = new URL(request.url);
+        const requestHeaders = new Headers({ accept: 'text/html' });
+        for (const name of ['user-agent', 'accept-language']) {
+            const value = request.headers.get(name);
+            if (value) {
+                requestHeaders.set(name, value);
+            }
+        }
+
+        const upstream = await fetch(`${FRAMER_ORIGIN}/${search}`, { headers: requestHeaders });
 
         const contentType = upstream.headers.get('content-type') ?? '';
         if (!upstream.ok || !contentType.includes('text/html')) {


### PR DESCRIPTION
## Problem

Since #627, `/` is rewritten to the Framer-hosted landing page (`zenstack.framer.website`) via `vercel.json`. A plain rewrite passes the body through untouched, so the page served at `zenstack.dev` declares the Framer domain in its `<link rel="canonical">` and `og:url` tags — telling search engines the canonical home of the site is `zenstack.framer.website`.

## Solution

Add Vercel Edge Middleware (`middleware.ts`, matched only on `/`) that fetches the Framer page and replaces the Framer origin with `https://zenstack.dev` before returning the HTML. The hostname appears exactly twice in the page (canonical + og:url), so a full-origin replacement is safe and fixes both.

The existing rewrite in `vercel.json` is kept as a fallback: if the middleware's fetch fails or returns non-HTML, it returns `undefined` and the request falls through to the plain rewrite, serving the unmodified Framer page instead of erroring.

## Testing

- Ran the compiled middleware against the live Framer page: output contains `<link rel="canonical" href="https://zenstack.dev/">` and `<meta property="og:url" content="https://zenstack.dev/">`, zero remaining `zenstack.framer.website` references.
- After deploy, verify with: `curl -s https://zenstack.dev/ | grep -E 'canonical|og:url'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed landing page experience for the root URL.
  * Landing page content is served seamlessly from the canonical site address.
  * Added fallback behavior to preserve the existing page delivery if the refreshed experience is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->