### PR TITLE
docs: parameterized computed fields

### DIFF
--- a/docs/orm/computed-fields.md
+++ b/docs/orm/computed-fields.md
@@ -5,6 +5,7 @@ description: Computed fields in ZModel
 
 import ZenStackVsPrisma from '../_components/ZenStackVsPrisma';
 import StackBlitzGithub from '@site/src/components/StackBlitzGithub';
+import AvailableSince from '../_components/AvailableSince';
 
 # Computed Fields
 
@@ -81,6 +82,8 @@ type ComputedFieldCallback = (
 ```
 
 ## Parameterized Computed Fields
+
+<AvailableSince version="v3.9.0" />
 
 A computed field can declare typed **parameters**, with the arguments supplied at query time wherever the field is used. This lets a single field express a database-side computation that depends on a runtime value — for example, "count a user's posts created since a given date", or the motivating case of "sort products by their tag name in a chosen category".
 

--- a/docs/orm/computed-fields.md
+++ b/docs/orm/computed-fields.md
@@ -80,6 +80,90 @@ type ComputedFieldCallback = (
 ) => OperandExpression<...>;
 ```
 
+## Parameterized Computed Fields
+
+A computed field can declare typed **parameters**, with the arguments supplied at query time wherever the field is used. This lets a single field express a database-side computation that depends on a runtime value — for example, "count a user's posts created since a given date", or the motivating case of "sort products by their tag name in a chosen category".
+
+Declare the parameters right after the field name in the ZModel schema (a parameterized field reads just like a regular one, with a parameter list added):
+
+```zmodel
+model User {
+    id    Int    @id
+    posts Post[]
+    recentPostCount(since: DateTime) Int @computed
+}
+```
+
+The implementation receives the arguments as a **third** parameter, after `eb` and `context`:
+
+```ts
+import { sql } from '@zenstackhq/orm/helpers';
+
+const db = new ZenStackClient(schema, {
+  ...
+  computedFields: {
+    User: {
+      // `args` is typed from the field's declared parameters: `{ since: Date }`
+      recentPostCount: (eb, { modelAlias }, args) =>
+        eb.selectFrom('Post')
+          .whereRef('Post.authorId', '=', sql.ref(`${modelAlias}.id`))
+          .where('Post.createdAt', '>=', args.since)
+          .select(({ fn }) => fn.countAll<number>().as('count')),
+    },
+  },
+});
+```
+
+Because the arguments are **plain data** (not a callback), they serialize over the wire — so a frontend can drive the query through the auto-CRUD API while it stays a single, policy-checked, `select`-narrowed statement.
+
+### Supplying arguments
+
+The `args` object travels with the field wherever it is used. Note that a parameterized field is **not** returned by default (it needs arguments), so a plain `findMany()` won't include it — you request it explicitly via `select`/`include`.
+
+```ts
+const since = new Date('2024-01-01');
+
+// orderBy — `{ args, sort, nulls? }`
+await db.user.findMany({ orderBy: { recentPostCount: { args: { since }, sort: 'desc' } } });
+
+// where (and `having`) — `args` alongside the filter operators
+await db.user.findMany({ where: { recentPostCount: { args: { since }, gte: 5 } } });
+
+// select / include
+await db.user.findMany({ include: { recentPostCount: { args: { since } } } });
+await db.user.findFirst({ select: { id: true, recentPostCount: { args: { since } } } });
+
+// aggregate — `_count` / `_sum` / `_avg` / `_min` / `_max`
+await db.user.aggregate({ _sum: { recentPostCount: { args: { since } } } });
+
+// groupBy — a keyed `{ field, args }` entry in `by`
+await db.user.groupBy({
+  by: [{ field: 'recentPostCount', args: { since } }],
+  _count: { _all: true },
+});
+```
+
+The full signature of a parameterized computed field implementation adds the `args` parameter:
+
+```ts
+import { OperandExpression, ExpressionBuilder } from 'kysely';
+
+type ParameterizedComputedFieldCallback = (
+  eb: ExpressionBuilder<...>,
+  context: {
+    modelAlias: string
+  },
+  args: {
+    // derived from the field's declared parameters, e.g. `since: DateTime` -> `since: Date`
+    since: Date
+  }
+) => OperandExpression<...>;
+```
+
+:::info
+Grouping **by** a computed field whose implementation is a *correlated subquery* is subject to your database's own rules for grouping by a correlated expression (PostgreSQL rejects it; SQLite allows it) — the same constraint that applies to any correlated `GROUP BY`. Computed fields defined by a row-local expression can be grouped on all databases.
+:::
+
 ## Samples
 
 <StackBlitzGithub repoPath="zenstackhq/v3-doc-orm-computed-fields" />


### PR DESCRIPTION
## What

Documents the parameterized `@computed` fields feature on the ORM **Computed Fields** page.

Adds a **Parameterized Computed Fields** section covering:

- the ZModel parameter syntax — `recentPostCount(since: DateTime) Int @computed`
- the implementation signature (a third `args` argument, typed from the declared parameters)
- supplying `args` across every read context: `orderBy`, `where` (and `having`), `select` / `include`, `aggregate` (`_count` / `_sum` / `_avg` / `_min` / `_max`), and `groupBy` `by`
- that a parameterized field isn't auto-returned (must be requested via `select` / `include`)
- a note that grouping *by* a correlated-subquery computed field is subject to the database's own correlated-`GROUP BY` rules

## Related

- Feature — `orderBy` support: zenstackhq/zenstack#2744
- Follow-up — `where` / `select` / `include` / `aggregate` / `groupBy`: zenstackhq/zenstack#2762

> This documents the API as of those PRs. Happy to adjust if the API shape changes during review — the page can merge alongside the v3.9 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using parameterized computed fields.
  * Documented typed schema parameters and callback argument handling.
  * Explained how to supply parameters in filtering, sorting, selection, aggregation, and grouping queries.
  * Clarified that parameterized computed fields are not returned by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->