### PR TITLE
docs: document native type mapping difference

### DIFF
--- a/docs/modeling/model.md
+++ b/docs/modeling/model.md
@@ -4,6 +4,7 @@ description: Models in ZModel
 ---
 
 import AvailableSince from '../_components/AvailableSince';
+import ZModelVsPSL from '../_components/ZModelVsPSL';
 
 # Model
 
@@ -192,6 +193,10 @@ model User {
 ```
 
 These attributes control what data type is used when the [migration engine](../orm/migration.md) maps the schema to DDL. You can find a complete list of native type attributes in the [ZModel Language Reference](../reference/zmodel/attribute#native-type-mapping-attributes).
+
+<ZModelVsPSL>
+Unlike PSL, all native type mapping attributes in ZModel use the `@db.` prefix, regardless of the name of your [`datasource`](./datasource.md).
+</ZModelVsPSL>
 
 ## Name mapping
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that ZModel native type-mapping attributes always use the `@db.` prefix, regardless of the configured datasource name.
  * Added an explicit comparison with PSL in the native type mapping guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->