### PR TITLE
docs: document `typing.exactQueryArgs` client option

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -83,6 +83,18 @@ export type ClientOptions<Schema extends SchemaDef> = {
    * Computed field definitions.
    */
   computedFields?: ComputedFieldsOptions<Schema>;      
+
+  /**
+   * Type-checking options for query arguments. Available since v3.9.0.
+   */
+  typing?: {
+    /**
+     * Recursively rejects unknown properties in query arguments. This is
+     * opt-in because the additional precision requires more work from the
+     * TypeScript checker. Defaults to `false`.
+     */
+    exactQueryArgs?: boolean;
+  };
 };
 ```
 


### PR DESCRIPTION
Documents the new `typing.exactQueryArgs` client option (available since v3.9.0) in the `ClientOptions` API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the optional `ClientOptions.typing.exactQueryArgs` setting.
  - Clarified that enabling this option recursively rejects unknown query properties.
  - Noted that the option is opt-in and defaults to `false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->