### PR TITLE
docs: document `--introspect` option of `zen proxy` command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,6 +4,8 @@ sidebar_position: 2
 sidebar_label: CLI
 ---
 
+import AvailableSince from '../_components/AvailableSince';
+
 # ZenStack CLI Reference
 
 ## Usage
@@ -323,9 +325,24 @@ Options:
   -o, --output <path>        output directory for `zen generate` command
   -d, --databaseUrl <url>    database connection URL
   -l, --logLevel <level...>  Query log levels (e.g., query, error)
+  --introspect               introspect the database to generate a schema when no schema file is found
   --no-version-check         do not check for new version
   -h, --help                 Show this help message
 ```
+
+#### The `--introspect` option
+
+<AvailableSince version="v3.9.0" />
+
+The `--introspect` option lets you start the proxy server without a ZModel schema file. It introspects the database (determined by the `-d, --databaseUrl` option or the `DATABASE_URL` environment variable), generates a schema from it, and runs code generation before starting the server. It's useful for bootstrapping from an existing database.
+
+```bash
+npx @zenstackhq/cli studio --introspect -d <databaseUrl>
+```
+
+:::warning
+The generated schema doesn't contain any access policies, so all data is accessible without restriction. Edit the schema to add access policies as needed.
+:::
 
 ## Overriding Default Options
 


### PR DESCRIPTION
## Summary

- Add the `--introspect` option to the `zen proxy` command reference (shipping in v3.9.0, zenstackhq/zenstack#2775)
- Add a subsection explaining the introspection flow (generates a schema from the database and runs codegen when no schema file exists) with a warning that the generated schema has no access policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)