### PR TITLE
docs: document the `client` in the computed field context

### DIFF
--- a/docs/orm/computed-fields.md
+++ b/docs/orm/computed-fields.md
@@ -72,14 +72,79 @@ The full signature of the computed field implementation is as follows:
 
 ```ts
 import { OperandExpression, ExpressionBuilder } from 'kysely';
+import { ClientContract } from '@zenstackhq/orm';
 
 type ComputedFieldCallback = (
   eb: ExpressionBuilder<...>,
   context: {
-    modelAlias: string
+    modelAlias: string,
+    client: ClientContract<Schema>
   }
 ) => OperandExpression<...>;
 ```
+
+## Accessing the Client
+
+<AvailableSince version="v3.9.1" />
+
+The `context` argument also carries `client` — the ORM client that's executing the query. Its main use is letting a computed field depend on *who is asking*, since the current user identity lives on the client rather than in the schema.
+
+```zmodel
+model User {
+    id    Int    @id
+    posts Post[]
+}
+
+model Post {
+    id       Int     @id
+    author   User    @relation(fields: [authorId], references: [id])
+    authorId Int
+    isMine   Boolean @computed
+}
+```
+
+```ts
+import { sql } from '@zenstackhq/orm/helpers';
+
+const db = new ZenStackClient(schema, {
+  ...
+  computedFields: {
+    Post: {
+      // `client.$auth` is the identity bound with `$setAuth()`, and `undefined`
+      // when the client is anonymous
+      isMine: (eb, { client }) =>
+        client.$auth
+          ? sql<boolean>`${eb.ref('authorId')} = ${client.$auth.id}`
+          : eb.lit(false),
+    },
+  },
+});
+```
+
+Because `$setAuth()` returns a *new* client rather than mutating the original, each user-bound client evaluates the field against its own identity:
+
+```ts
+const userDb = db.$setAuth({ id: 1 });
+
+// only user 1's posts
+await userDb.post.findMany({ where: { isMine: true } });
+
+// => { ..., isMine: true }
+await userDb.post.findUnique({ where: { id: 1 } });
+
+// the original client is anonymous and unaffected => { ..., isMine: false }
+await db.post.findUnique({ where: { id: 1 } });
+```
+
+The per-request client that a web app already creates (see [Setting Auth User](./access-control/query.md#setting-auth-user)) therefore carries its identity into every computed field it evaluates, with no module-level state to keep in sync. Reading `$auth` this way doesn't require the access policy plugin — `$setAuth()` and `$auth` are part of the base client.
+
+:::info
+A computed field implementation must return its expression **synchronously**, so `client` is meant for reading per-client state such as `$auth`. It is not a way to `await` queries while building a computed field — data-dependent logic belongs in the expression itself, for example as a correlated subquery.
+:::
+
+:::tip
+The `sql` fragment above is what types a `Boolean @computed` field. A Kysely comparison like `eb('authorId', '=', id)` evaluates correctly, but its type is `SqlBool` (`boolean | 0 | 1`), which doesn't satisfy the `OperandExpression<boolean>` that a `Boolean` field expects. A `sql<boolean>` fragment, `eb.lit()`, or a `CASE` expression built with `eb.case()` all give you the right type.
+:::
 
 ## Parameterized Computed Fields
 
@@ -150,11 +215,13 @@ The full signature of a parameterized computed field implementation adds the `ar
 
 ```ts
 import { OperandExpression, ExpressionBuilder } from 'kysely';
+import { ClientContract } from '@zenstackhq/orm';
 
 type ParameterizedComputedFieldCallback = (
   eb: ExpressionBuilder<...>,
   context: {
-    modelAlias: string
+    modelAlias: string,
+    client: ClientContract<Schema>
   },
   args: {
     // derived from the field's declared parameters, e.g. `since: DateTime` -> `since: Date`


### PR DESCRIPTION
Documents the `client` property of the computed field context, added in [v3.9.1](https://github.com/zenstackhq/zenstack/releases/tag/v3.9.1) by zenstackhq/zenstack#2789.

### Changes

`docs/orm/computed-fields.md`:

- New **Accessing the Client** section (`<AvailableSince version="v3.9.1" />`) — what `context.client` is, the `isMine` example reading `client.$auth`, and how a `$setAuth()`-derived client evaluates the field against its own identity while the original stays anonymous. Links to [Setting Auth User](https://zenstack.dev/docs/orm/access-control/query#setting-auth-user) for the per-request client pattern.
- `client` added to both callback signature blocks (`ComputedFieldCallback` and `ParameterizedComputedFieldCallback`).
- Two callouts: the implementation returns its expression **synchronously**, so `client` is for reading per-client state rather than awaiting queries; and a note on why the example uses a `sql<boolean>` fragment (see below).

### On the `sql<boolean>` fragment

The natural way to write `isMine` is `eb('authorId', '=', id)`, but that doesn't typecheck against a `Boolean @computed` field. The generated stub returns `boolean`, so the callback must return `OperandExpression<boolean>`, while a Kysely comparison is `SqlBool` (`boolean | 0 | 1`):

```
Type 'ExpressionWrapper<ToKyselySchema<SchemaType>, "Post", SqlBool>' is not assignable
  to type 'OperandExpression<boolean>'.
```

So the example uses `sql<boolean>` and the tip lists the alternatives that also type correctly (`eb.lit()`, `eb.case()`). Happy to switch to whichever form you consider idiomatic — or drop the tip if `SqlBool` is something you'd rather accept in `OperandExpression` on the ORM side.

### Verification

- Documented implementation runs green against a real client on **sqlite** and **postgresql** — `where: { isMine: true }`, `findUnique` on both an authed and an anonymous client.
- Type-checked against a generated schema with a `Boolean @computed` field: `eb.lit()` / `sql<boolean>` / `eb.case()` pass, and `client.$auth?.id` narrows to `number | undefined`.
- `npm run build` passes (`onBrokenLinks: 'throw'`), so the anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented access to per-client state in computed field callbacks.
  - Added an example of identity-dependent computed fields.
  - Clarified `$setAuth()` behavior, synchronous expression requirements, and boolean typing.
  - Updated parameterized computed field callback documentation to include client context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->