### PR TITLE
docs: document `@@strict` attribute

### DIFF
--- a/docs/orm/typed-json.md
+++ b/docs/orm/typed-json.md
@@ -4,6 +4,7 @@ description: Strongly typed JSON fields
 ---
 
 import ZenStackVsPrisma from '../_components/ZenStackVsPrisma';
+import AvailableSince from '../_components/AvailableSince';
 import StackBlitzGithub from '@site/src/components/StackBlitzGithub';
 
 # Strongly Typed JSON
@@ -15,7 +16,11 @@ Strongly typed JSON is a ZModel feature and doesn't exist in Prisma.
 ZModel allows you to define custom types and use them to [type JSON fields](../modeling/typed-json.md). The ORM respects such fields in two ways:
 
 1. The return type of such fields is typed as TypeScript types derived from the ZModel custom type definition.
-2. When creating or updating such fields, the ORM validates the input against the custom type definition. The engine "loosely" validates the mutation input and doesn't prevent you from including fields not defined in the custom type.
+2. When creating or updating such fields, the ORM validates the input against the custom type definition. By default, the engine "loosely" validates the mutation input and doesn't prevent you from including fields not defined in the custom type.
+
+<AvailableSince version="v3.9.2" />
+
+You can indicate the ORM should reject unknown fields by decorating the custom type definition with the `@@strict` attribute. The presence of unknown fields would then be considered both a compilation error and a runtime validation error.
 
 ## Samples
 

--- a/docs/orm/typed-json.md
+++ b/docs/orm/typed-json.md
@@ -18,6 +18,8 @@ ZModel allows you to define custom types and use them to [type JSON fields](../m
 1. The return type of such fields is typed as TypeScript types derived from the ZModel custom type definition.
 2. When creating or updating such fields, the ORM validates the input against the custom type definition. By default, the engine "loosely" validates the mutation input and doesn't prevent you from including fields not defined in the custom type.
 
+## Strict JSON
+
 <AvailableSince version="v3.9.2" />
 
 You can indicate the ORM should reject unknown fields by decorating the custom type definition with the `@@strict` attribute. The presence of unknown fields would then be considered both a compilation error and a runtime validation error.

--- a/docs/orm/typed-json.md
+++ b/docs/orm/typed-json.md
@@ -22,7 +22,7 @@ ZModel allows you to define custom types and use them to [type JSON fields](../m
 
 <AvailableSince version="v3.9.2" />
 
-You can indicate the ORM should reject unknown fields by decorating the custom type definition with the `@@strict` attribute. The presence of unknown fields would then be considered both a compilation error and a runtime validation error.
+You can indicate the ORM should reject unknown fields by decorating the custom type definition with the `@@strict` attribute. The presence of unknown fields would then be reported as both a compilation error and a runtime validation error.
 
 ## Samples
 

--- a/docs/reference/zmodel/attribute.md
+++ b/docs/reference/zmodel/attribute.md
@@ -406,7 +406,7 @@ model User {
 }
 ```
 
-<AvailableSince version="3.9.2" />
+<AvailableSince version="v3.9.2" />
 
 ### @@strict
 

--- a/docs/reference/zmodel/attribute.md
+++ b/docs/reference/zmodel/attribute.md
@@ -2,6 +2,8 @@
 sidebar_position: 7
 ---
 
+import AvailableSince from '../../_components/AvailableSince';
+
 # Attribute
 
 Attributes decorate fields and models and attach extra behaviors or constraints to them.
@@ -401,6 +403,28 @@ model User {
     id Int @id
     name String
     @@schema("auth")
+}
+```
+
+<AvailableSince version="3.9.2" />
+
+### @@strict
+
+```zmodel
+attribute @@strict()
+```
+
+Indicates [strongly-typed JSON](../../orm/typed-json) should reject unknown fields.
+
+```zmodel
+model User {
+    id Int @id
+    profile Profile @json
+}
+
+type Profile {
+    name String
+    @@strict
 }
 ```
 

--- a/docs/reference/zmodel/attribute.md
+++ b/docs/reference/zmodel/attribute.md
@@ -406,9 +406,9 @@ model User {
 }
 ```
 
-<AvailableSince version="v3.9.2" />
-
 ### @@strict
+
+<AvailableSince version="v3.9.2" />
 
 ```zmodel
 attribute @@strict()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the `@@strict` attribute for strongly typed JSON fields.
  * Clarified that strict validation rejects unknown fields during compilation and runtime validation.
  * Added availability information for this behavior in version 3.9.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->